### PR TITLE
make ssl_verify optional

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -95,6 +95,7 @@ def install_rpm
               :name          => filename,
               :repo_gpgcheck => 1,
               :description   => filename,
+              :ssl_verify    => new_resource.ssl_verify,
               :priority      => new_resource.priority
  
     notifies :run, "execute[yum-makecache-#{filename}]", :immediately

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -6,3 +6,4 @@ attribute :master_token,  :kind_of => String
 attribute :type,          :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :gpg_key_url,   :kind_of => String, :default => node['packagecloud']['gpg_key_url']
 attribute :priority,      :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
+attribute :ssl_verify,    :kind_of => [TrueClass, FalseClass], :default => true

--- a/templates/default/yum.erb
+++ b/templates/default/yum.erb
@@ -8,5 +8,5 @@ priority=<%=@priority %>
 gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-packagecloud
-sslverify=1
+sslverify=<%= @ssl_verify ? 1 : 0 %>
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
In rhel5 theres some issues with root CA certs and even possibly the python https libs that keep preventing https repos from operating right. This patch makes it so you could feasibly allow ssl_verify to be disabled. It's terrible but ther wasn't a good way out. 
