### PR TITLE
Add supported codename, default codename

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@ platforms:
     - recipe[packagecloud_test::lucid_deps]
     - recipe[packagecloud_test::deb]
     - recipe[packagecloud_test::rubygems_private]
+    - recipe[packagecloud_test::supported_codenames]
 
 - name: ubuntu-12.04
   driver_config:
@@ -33,14 +34,14 @@ platforms:
 
 - name: centos-without-epel-5.10
   driver_config:
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
+    box: opscode-centos-5.10
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems]
 
 - name: centos-with-epel-5.10
   driver_config:
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
+    box: opscode-centos-5.10
   run_list:
     - recipe[packagecloud_test::epel5]
     - recipe[packagecloud_test::rpm]
@@ -77,3 +78,13 @@ suites:
 - name: default
   run_list:
   attributes: {}
+
+- name: supported-codename
+  excludes:
+    - centos-without-epel-5.10
+    - centos-with-epel-5.10
+    - centos-6.5
+    - centos-7.0
+    - amazon-2014.09
+  run_list:
+    - recipe[packagecloud_test::supported_codenames]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,32 @@ packagecloud_repo "computology/packagecloud-cookbook-test-private" do
 end
 ```
 
-Valid options for `type` include `deb`, `rpm`, and `gem`.
+### Deb Repositories
+
+If a repository publishes packages for only certain codenames, for
+example Ubuntu 10.04 and 12.04, and you're using a platform that isn't
+supported, such as Ubuntu 14.04, you can specify a codename to use by
+default, as "YOLO."
+
+```ruby
+packagecloud_repo 'chef/stable' do
+  supported_codenames ['lucid', 'precise']
+  default_codename 'lucid'
+end
+```
+
+If you want to specify a particular codename no matter what, just use
+`default_codename` without supported codenames.
+
+```ruby
+packagecloud_repo 'basho/riak' do
+  default_codename 'lucid'
+end
+```
+
+Valid options for `type` include `deb`, `rpm`, and `gem`. The provider
+will use the `node['packagecloud']['default_type']` attribute, which
+is determined by platform.
 
 ## Interactions with other cookbooks
 

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -6,3 +6,5 @@ attribute :master_token,  :kind_of => String
 attribute :type,          :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :gpg_key_url,   :kind_of => String, :default => node['packagecloud']['gpg_key_url']
 attribute :priority,      :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
+attribute :supported_codenames, :kind_of => [Array], :default => []
+attribute :default_codename,    :kind_of => String

--- a/test/fixtures/cookbooks/packagecloud_test/recipes/supported_codenames.rb
+++ b/test/fixtures/cookbooks/packagecloud_test/recipes/supported_codenames.rb
@@ -1,0 +1,10 @@
+packagecloud_repo 'chef/stable' do
+  supported_codenames ['natty', 'raring', 'saucy']
+  default_codename 'lucid'
+end
+
+packagecloud_repo 'basho/riak-cs'
+
+packagecloud_repo 'basho/riak' do
+  default_codename 'precise'
+end

--- a/test/integration/supported-codenames/serverspec/ubuntu_only_spec.rb
+++ b/test/integration/supported-codenames/serverspec/ubuntu_only_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'supported-codenames' do
+  describe file('/etc/apt/sources.list.d/chef_stable.list') do
+    its(:content) { should match %r[deb https://packagecloud.io/chef/stable/ubuntu lucid main] }
+  end
+
+  describe file('/etc/apt/sources.list.d/basho_riak-cs.list') do
+    its(:content) { should match %r[deb https://packagecloud.io/basho/riak-cs/ubuntu \w+ main] }
+  end
+
+  describe file('/etc/apt/sources.list.d/basho_riak.list') do
+    its(:content) { should match %r[deb https://packagecloud.io/basho/riak/ubuntu precise main] }
+  end
+
+end


### PR DESCRIPTION
This commit introduces a helper method to allow setting supported
"LSB" codenames with a default/fallback codename.

It may be desirable to better control the distribution codename used
on debian-ish platforms when consuming Package Cloud repositories. For
example, a repository might release packages for "trusty" only, but
those packages might install and work just fine on "lucid" or
"precise."

This is backwards compatible. If the `supported_codenames` or
`default_codenames` attributes are not specified on a resource, it
behaves as before, using `node['lsb']['codename']`'s value.

Changes:
- Add `supported_codenames` and `default_codename` attributes to the
  `packagecloud_repo` resource
- Add `distro_codename` to `packagecloud_repo` provider to delegate
  selection of the appropriate codename
- Create new recipe and serverspec test for testing this feature
- Create a test suite in `.kitchen.yml` for testing this (non-RHEL)
- Update the README describing how to use this for deb repositories
