### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This is the Changelog for the packagecloud cookbook
 
+## Unreleased
+
+- resolved cookstyle error: Thorfile:1:1 convention: `Style/Encoding`
+- resolved cookstyle error: libraries/matchers.rb:1:1 refactor: `Chef/Modernize/DefinesChefSpecMatchers`
+- resolved cookstyle error: metadata.rb:6:1 refactor: `Chef/RedundantCode/LongDescriptionMetadata`
+- resolved cookstyle error: metadata.rb:8:1 refactor: `Chef/Modernize/RespondToInMetadata`
+- resolved cookstyle error: metadata.rb:9:1 refactor: `Chef/Modernize/RespondToInMetadata`
+- resolved cookstyle error: metadata.rb:10:1 refactor: `Chef/Modernize/RespondToInMetadata`
+- resolved cookstyle error: resources/repo.rb:23:1 refactor: `Chef/Modernize/ClassEvalActionClass`
+- resolved cookstyle error: resources/repo.rb:72:41 convention: `Layout/TrailingWhitespace`
+- resolved cookstyle error: resources/repo.rb:72:42 refactor: `Chef/Modernize/FoodcriticComments`
+
 ## v1.0.1 (2018-10-25)
 
 Fix issues with newer versions of Chef (11+) by conditionally defining `source_url` and `issues_url` in metadata.rb

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler'
 require 'bundler/setup'
 require 'berkshelf/thor'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,11 +1,1 @@
-if defined?(ChefSpec)
-  ChefSpec.define_matcher :packagecloud_repo
 
-  def create_packagecloud_repo(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:packagecloud_repo, :add, resource_name)
-  end
-
-  def add_packagecloud_repo(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:packagecloud_repo, :add, resource_name)
-  end
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,10 @@ maintainer 'Joe Damato'
 maintainer_email 'joe@packagecloud.io'
 license 'Apache-2.0'
 description 'Installs/Configures packagecloud.io repositories.'
-long_description 'Installs/Configures packagecloud.io repositories.'
 version '1.0.1'
-source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
-issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)
-chef_version '>= 12.5' if respond_to?(:chef_version)
+source_url 'https://github.com/computology/packagecloud-cookbook'
+issues_url 'https://github.com/computology/packagecloud-cookbook/issues'
+chef_version '>= 12.5'
 %w(ubuntu debian redhat centos amazon oracle fedora scientific).each do |p|
   supports p
 end

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -20,7 +20,7 @@ action :add do
   end
 end
 
-action_class.class_eval do
+action_class do
   include ::PackageCloud::Helper
 
   require 'uri'
@@ -69,7 +69,7 @@ action_class.class_eval do
       notifies :run, "execute[apt-get-update-#{filename}]", :immediately
     end
 
-    execute "apt-key-add-#{filename}" do # ~FC041
+    execute "apt-key-add-#{filename}" do
       command lazy {
         gpg_url = gpg_url(new_resource.base_url, new_resource.repository, :deb, new_resource.master_token)
         "wget --auth-no-challenge -qO - #{gpg_url} | apt-key add -"


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with Thorfile

 - 1:1 convention: `Style/Encoding` - Unnecessary utf-8 encoding comment. (https://rubystyle.guide#utf-8)

### Issues found and resolved with libraries/matchers.rb

 - 1:1 refactor: `Chef/Modernize/DefinesChefSpecMatchers` - ChefSpec matchers are now auto generated by ChefSpec 7.1+ and do not need to be defined in a cookbook (https://docs.chef.io/workstation/cookstyle/chef_modernize_defineschefspecmatchers)

### Issues found and resolved with metadata.rb

 - 6:1 refactor: `Chef/RedundantCode/LongDescriptionMetadata` - The long_description metadata.rb method is not used and is unnecessary in cookbooks. (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_longdescriptionmetadata)
 - 8:1 refactor: `Chef/Modernize/RespondToInMetadata` - It is no longer necessary to use respond_to? or defined? in metadata.rb in Chef Infra Client 12.15 and later (https://docs.chef.io/workstation/cookstyle/chef_modernize_respondtoinmetadata)
 - 9:1 refactor: `Chef/Modernize/RespondToInMetadata` - It is no longer necessary to use respond_to? or defined? in metadata.rb in Chef Infra Client 12.15 and later (https://docs.chef.io/workstation/cookstyle/chef_modernize_respondtoinmetadata)
 - 10:1 refactor: `Chef/Modernize/RespondToInMetadata` - It is no longer necessary to use respond_to? or defined? in metadata.rb in Chef Infra Client 12.15 and later (https://docs.chef.io/workstation/cookstyle/chef_modernize_respondtoinmetadata)

### Issues found and resolved with resources/repo.rb

 - 23:1 refactor: `Chef/Modernize/ClassEvalActionClass` - In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)
 - 72:41 convention: `Layout/TrailingWhitespace` - Trailing whitespace detected. (https://rubystyle.guide#no-trailing-whitespace)
 - 72:42 refactor: `Chef/Modernize/FoodcriticComments` - Remove legacy code comments that disable Foodcritic rules (https://docs.chef.io/workstation/cookstyle/chef_modernize_foodcriticcomments)